### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pydicom
-dcmstack
 rdflib
 nipype
+funcsigs
+configparser
+dcmstack


### PR DESCRIPTION
`dcmstack` fails, but then heudiconv fails without funcsigs and configparser